### PR TITLE
Update to python3 plugin (3.8 recommended), drop python2 support, fix use of "Setting" to be "Settings" from the current binaryninja-api source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.vs/

--- a/__init__.py
+++ b/__init__.py
@@ -1,19 +1,17 @@
 import sys
-if sys.platform == 'win32':
-    sys.path.append('C:\Python27\Lib\site-packages')
 
 from binaryninja import *
 
-from frida_plugin_start import FridaPluginStart
-from frida_plugin_attach import FridaPluginAttach
-from frida_plugin_stop import FridaPluginStop
-from frida_plugin_intercept import FridaPluginIntercept
-from frida_plugin_modify import FridaPluginModify
-from frida_plugin_remove import FridaPluginRemove
-from frida_plugin_reload import FridaPluginReload
+from .frida_plugin_start import FridaPluginStart
+from .frida_plugin_attach import FridaPluginAttach
+from .frida_plugin_stop import FridaPluginStop
+from .frida_plugin_intercept import FridaPluginIntercept
+from .frida_plugin_modify import FridaPluginModify
+from .frida_plugin_remove import FridaPluginRemove
+from .frida_plugin_reload import FridaPluginReload
 
 intercepts = {}
-settings = Setting("binaryninja-frida")
+settings = Settings("binaryninja-frida")
 
 plugin_commands = [
     {

--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,10 @@ from .frida_plugin_reload import FridaPluginReload
 
 intercepts = {}
 settings = Settings("binaryninja-frida")
+settings.register_group("frida", "Frida Settings")
+settings.register_setting("frida.device_id", '{"description" : "Currently selected device id.", "title" : "Frida Device ID", "default" : "", "type" : "string"}')
+settings.register_setting("frida.process_name", '{"description" : "Currently selected process name", "title" : "Frida Selected Process Name", "default" : "", "type" : "string"}')
+
 
 plugin_commands = [
     {

--- a/frida_intercept.py
+++ b/frida_intercept.py
@@ -1,8 +1,11 @@
+from builtins import str
+from builtins import range
+from builtins import object
 from binaryninja import *
 
 import base64
 
-class FridaIntercept:
+class FridaIntercept(object):
     def __init__(self, addr, params, ret, module_name=None, abi='default'):
         self.addr = addr
         self.params = params

--- a/frida_intercept.py
+++ b/frida_intercept.py
@@ -1,6 +1,3 @@
-from builtins import str
-from builtins import range
-from builtins import object
 from binaryninja import *
 
 import base64

--- a/frida_plugin.py
+++ b/frida_plugin.py
@@ -1,10 +1,11 @@
+from builtins import object
 from binaryninja import *
 
 import frida
 import os
 import json
 
-from frida_intercept import FridaIntercept
+from .frida_intercept import FridaIntercept
 
 class FridaPlugin(object):
     def __init__(self, settings):
@@ -20,7 +21,7 @@ class FridaPlugin(object):
             self.intercepts = {}
             serialized_intercepts = json.loads(bv.query_metadata("frida_plugin_intercepts"))
             
-            for addr, intercept in serialized_intercepts.items():
+            for addr, intercept in list(serialized_intercepts.items()):
                 if addr not in self.intercepts:
                     self.intercepts[addr] = FridaIntercept.deserialize(intercept)
                     
@@ -32,7 +33,7 @@ class FridaPlugin(object):
 
     def _store_metadata(self, bv):
         serialized_intercepts = {}
-        for addr, intercept in self.intercepts.items():
+        for addr, intercept in list(self.intercepts.items()):
             serialized_intercepts[addr] = intercept.serialize()
 
         bv.store_metadata("frida_plugin_intercepts", json.dumps(serialized_intercepts))
@@ -58,7 +59,7 @@ class FridaPlugin(object):
         bv.session_data["module_name"] = self.module_name
     
     def _reload_intercepts(self):
-        for addr, intercept in self.intercepts.items():
+        for addr, intercept in list(self.intercepts.items()):
             intercept.update_function_def(self.global_bv.get_functions_containing(int(addr, 16))[0])
             if intercept.is_running and intercept.is_invalidated():
                 intercept.reload(self.frida_session.create_script(intercept.to_frida_script()))

--- a/frida_plugin.py
+++ b/frida_plugin.py
@@ -1,4 +1,3 @@
-from builtins import object
 from binaryninja import *
 
 import frida

--- a/frida_plugin_attach.py
+++ b/frida_plugin_attach.py
@@ -12,7 +12,7 @@ class FridaPluginAttach(FridaPlugin):
         return self.frida_device != None
 
     def run(self, bv, function=None):
-        device_id = self.settings.get_string("device_id")
+        device_id = self.settings.get_string("frida.device_id")
         if device_id:
             device = None
             try:
@@ -25,7 +25,7 @@ class FridaPluginAttach(FridaPlugin):
             try:
                 last_process = bv.query_metadata("frida_plugin_process_name")
             except KeyError:
-                last_process = self.settings.get_string("process_name")
+                last_process = self.settings.get_string("frida.process_name")
 
             processes = []
             processes_reorder = []
@@ -39,7 +39,7 @@ class FridaPluginAttach(FridaPlugin):
             choice_f = ChoiceField("Processes", processes)
             get_form_input([choice_f], "Attach Frida to Process")
             if choice_f.result != None:
-                self.settings.set_string("process_name", processes_reorder[choice_f.result].name)
+                self.settings.set_string("frida.process_name", processes_reorder[choice_f.result].name)
                 bv.store_metadata("frida_plugin_process_name", str(processes_reorder[choice_f.result].name))
                 process = processes_reorder[choice_f.result]
                 self.frida_session = device.attach(process.pid)

--- a/frida_plugin_attach.py
+++ b/frida_plugin_attach.py
@@ -1,4 +1,5 @@
-from frida_plugin import FridaPlugin
+from builtins import str
+from .frida_plugin import FridaPlugin
 
 from binaryninja import *
 import os
@@ -47,7 +48,7 @@ class FridaPluginAttach(FridaPlugin):
                 filename = os.path.split(bv.file.filename)[-1].split('.')[0] + '.'
                 self.module_name = filename
 
-                for addr, intercept in self.intercepts.items():
+                for addr, intercept in list(self.intercepts.items()):
                     if intercept.is_enabled:
                         intercept.set_module_name(self.module_name)
                         intercept.start(self.frida_session.create_script(intercept.to_frida_script()))

--- a/frida_plugin_attach.py
+++ b/frida_plugin_attach.py
@@ -1,4 +1,3 @@
-from builtins import str
 from .frida_plugin import FridaPlugin
 
 from binaryninja import *

--- a/frida_plugin_intercept.py
+++ b/frida_plugin_intercept.py
@@ -1,4 +1,4 @@
-from frida_plugin import FridaPlugin
+from .frida_plugin import FridaPlugin
 
 from binaryninja import *
 

--- a/frida_plugin_modify.py
+++ b/frida_plugin_modify.py
@@ -1,4 +1,4 @@
-from frida_plugin import FridaPlugin
+from .frida_plugin import FridaPlugin
 
 from binaryninja import *
 

--- a/frida_plugin_reload.py
+++ b/frida_plugin_reload.py
@@ -1,4 +1,4 @@
-from frida_plugin import FridaPlugin
+from .frida_plugin import FridaPlugin
 
 class FridaPluginReload(FridaPlugin):
     def __init__(self, settings):

--- a/frida_plugin_remove.py
+++ b/frida_plugin_remove.py
@@ -1,4 +1,4 @@
-from frida_plugin import FridaPlugin
+from .frida_plugin import FridaPlugin
 
 from binaryninja import *
 

--- a/frida_plugin_start.py
+++ b/frida_plugin_start.py
@@ -1,4 +1,5 @@
-from frida_plugin import FridaPlugin
+from builtins import str
+from .frida_plugin import FridaPlugin
 
 from binaryninja import *
 import frida

--- a/frida_plugin_start.py
+++ b/frida_plugin_start.py
@@ -12,7 +12,7 @@ class FridaPluginStart(FridaPlugin):
         try:
             last_device = bv.query_metadata("frida_plugin_device_id")
         except KeyError:
-            last_device = self.settings.get_string("device_id")
+            last_device = self.settings.get_string("frida.device_id")
 
         devices = []
         device_reorder = []
@@ -26,6 +26,6 @@ class FridaPluginStart(FridaPlugin):
         choice_f = ChoiceField("Devices", devices)
         get_form_input([choice_f], "Get Frida Device")
         if choice_f.result != None:
-            self.settings.set_string("device_id", device_reorder[choice_f.result].id)
+            self.settings.set_string("frida.device_id", device_reorder[choice_f.result].id)
             bv.store_metadata("frida_plugin_device_id", str(device_reorder[choice_f.result].id))
             self.frida_device = device_reorder[choice_f.result]

--- a/frida_plugin_start.py
+++ b/frida_plugin_start.py
@@ -1,4 +1,3 @@
-from builtins import str
 from .frida_plugin import FridaPlugin
 
 from binaryninja import *

--- a/frida_plugin_stop.py
+++ b/frida_plugin_stop.py
@@ -1,11 +1,11 @@
-from frida_plugin import FridaPlugin
+from .frida_plugin import FridaPlugin
 
 class FridaPluginStop(FridaPlugin):
     def __init__(self, settings):
         super(FridaPluginStop, self).__init__(settings)
     
     def run(self, bv, function=None):
-        for addr, intercept in self.intercepts.items():
+        for addr, intercept in list(self.intercepts.items()):
             if intercept.is_enabled == True:
                 log.log_info("Frida Plugin: Removing intercept at %s" % intercept.addr)
                 intercept.stop()

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "Frida",
 	"type": ["helper"],
-	"api": ["python2", "python3"],
+	"api": ["python3"],
 	"pluginmetadataversion": 2,
 	"platforms": ["Linux", "Windows", "Darwin"],
 	"installinstructions" : {


### PR DESCRIPTION
Binary Ninja plugins are being updated to focus on Python3, this update does this. Also, it fixes the Setting changed to Settings issue from binaryninja-api. This pull request has no additional package requirements than the original release, it does, however, drops support for python2. If you want me to utilize futurize/poetry packages (like builtins) to make it compatible between python2 and python 3.8.1  users I can do that, it will require additional dependencies be installed by the user though. My original pull request (now closed) was the beginnings of cross-compatibility between python2/3 but to reduce install requirements I chose to reduce it to a python3 only plugin. Let me know your thoughts on this. 
